### PR TITLE
Adds a Dockerfile for the CLI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+.git

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,43 @@
+name: Publish Docker Image
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - v*
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ukanga/putio
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM rust:1.86 AS builder
+WORKDIR /putio/
+COPY ./ ./
+RUN cargo build --release
+
+# Unfortunately some of the CLI dependencies do not allow building a
+# statically linked binary. Using Ubuntu as the runner instead of a
+# lighter image like Alpine because of known incompatiblities between
+# the minimal libc (musl) that ships with Alpine and the more typical
+# libc the binary is built using.
+FROM ubuntu:24.04 AS runner
+COPY --from=builder /putio/target/release/putio /usr/bin/putio
+RUN apt update && apt install -y aria2 wget curl


### PR DESCRIPTION
This PR adds a Dockerfile for the putio CLI. The built image also contains common tools used for downloading to pair with the putio CLI.

This commit also adds a GitHub workflow configuration for publishing built images to the GitHub Container Registry.

Testing
=======

Testing only done on the built image. Image built using. Image built and tested using:

```sh
podman build -t putio:latest -f Dockerfile .
podman run -it --rm putio <redacted OAuth2 token> <redacted folder id>
```

I'm unable to test the GitHub workflow. Hopefully it works but open to updating it if it doesn't.